### PR TITLE
Builder worker with queue

### DIFF
--- a/master_node/build_manager/BuildManager.py
+++ b/master_node/build_manager/BuildManager.py
@@ -34,6 +34,7 @@ def find_project(project_id):
 
     """
     # TODO currently fetching hard coded pk. Implement dynamic handling.
+    project_id = int(project_id)
     p = Project.objects.get(pk=project_id)
     print(p)
 
@@ -87,10 +88,10 @@ def download_python_dependencies(project):
 
 def download_go_dependencies(project):
     popen = subprocess.Popen(["build_manager/scripts/get_dependencies_golang.sh", project_dictionary[project.pk]],
-                    stdout =subprocess.PIPE)
+                             stdout=subprocess.PIPE)
     lines_iterator = iter(popen.stdout.readline, b"")
     for line in lines_iterator:
-        print(line) # yield line
+        print(line)  # yield line
 
     create_zip(project, GOLANG)
 

--- a/master_node/build_manager/BuilderWorker.py
+++ b/master_node/build_manager/BuilderWorker.py
@@ -1,0 +1,51 @@
+__author__ = 'saurabh'
+import http.client
+import json
+from .BuildManager import find_project
+import time
+import traceback
+
+
+def fetchTask():
+    conn = http.client.HTTPConnection("localhost:4242")
+    conn.request("GET", "/queue/dequeue/Build_Manager_Queue1")
+    r1 = conn.getresponse()
+    print(r1.status, r1.reason)
+    data1 = r1.read().decode("utf-8")
+    request = json.loads(data1)
+    if 'error' in request.keys():
+        print("Nothing to do... Sleeping.. ")
+        time.sleep(5)
+        return
+
+    try:
+        print(request)
+        task = json.loads(request['data'])
+        print(task)
+        find_project(task['project_id'])
+        print("Adding task to success queue", request)
+        addToQueue(True, request)
+    except Exception:
+        print(traceback.format_exc())
+        addToQueue(False, request)
+        print("Exception occurred... Failing task.. ", request)
+
+
+def addToQueue(success, request):
+    params = json.dumps({"topic": "Build_Manager_Queue1", "task_id": request['task_id']})
+    headers = {"Content-type": "application/x-www-form-urlencoded", "Accept": "text/plain"}
+    conn = http.client.HTTPConnection("localhost:4242")
+    if success:
+        conn.request("POST", "/queue/successq", params, headers)
+    else:
+        conn.request("POST", "/queue/failureq", params, headers)
+    response = conn.getresponse()
+    print(response.status, response.reason)
+    data = response.read()
+    print(data)
+    conn.close()
+
+
+def startWorker():
+    while True:
+        fetchTask()

--- a/master_node/build_manager/__init__.py
+++ b/master_node/build_manager/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'build_manager.apps.BuildManagerConfig'

--- a/master_node/build_manager/apps.py
+++ b/master_node/build_manager/apps.py
@@ -2,6 +2,8 @@ __author__ = 'saurabh'
 import http.client, urllib.parse
 from django.apps import AppConfig
 import json
+from .BuilderWorker import startWorker
+import threading
 
 
 class BuildManagerConfig(AppConfig):

--- a/master_node/build_manager/apps.py
+++ b/master_node/build_manager/apps.py
@@ -1,0 +1,24 @@
+__author__ = 'saurabh'
+import http.client, urllib.parse
+from django.apps import AppConfig
+import json
+
+
+class BuildManagerConfig(AppConfig):
+    name = 'build_manager'
+    verbose_name = "build_manager"
+    is_initialized = False
+
+    def ready(self):
+        if not self.is_initialized:
+            self.initialize_queues()
+
+    def initialize_queues(self):
+        params = json.dumps({"topic": "Build_Manager_Queue1", "size": 10})
+        headers = {"Content-type": "application/x-www-form-urlencoded", "Accept": "text/plain"}
+        conn = http.client.HTTPConnection("localhost:4242")
+        conn.request("POST", "/queue/", params, headers)
+        response = conn.getresponse()
+        print(response.status, response.reason)
+        data = response.read()
+        conn.close()

--- a/master_node/build_manager/urls.py
+++ b/master_node/build_manager/urls.py
@@ -4,5 +4,5 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^$', views.index, name='index'),
+    url(r'^(?P<project_id>\d{0,11})$', views.index, name='views.index'),
 ]

--- a/master_node/build_manager/views.py
+++ b/master_node/build_manager/views.py
@@ -2,16 +2,22 @@
 from django.http import HttpResponse
 import http.client, urllib.parse
 from .BuildManager import *
+import json
+from .BuilderWorker import startWorker
+import threading
 
 
-def index(request):
-    find_project(4)
-    params = urllib.parse.urlencode({'@number': 12524, '@type': 'issue', '@action': 'show'})
+def index(request, project_id):
+    data = json.dumps({'project_id': project_id})
+    params = json.dumps({"topic": "Build_Manager_Queue1", "data": data, "priority": 3})
     headers = {"Content-type": "application/x-www-form-urlencoded", "Accept": "text/plain"}
-    conn = http.client.HTTPConnection("bugs.python.org")
-    conn.request("POST", "", params, headers)
+    conn = http.client.HTTPConnection("localhost:4242")
+    conn.request("POST", "/queue/enqueue", params, headers)
     response = conn.getresponse()
     print(response.status, response.reason)
     data = response.read()
+    print(data)
     conn.close()
-    return HttpResponse("Hello, world. You're at the build manager index.")
+    thread = threading.Thread(target=startWorker)
+    thread.start()
+    return HttpResponse(data)

--- a/master_node/build_manager/views.py
+++ b/master_node/build_manager/views.py
@@ -1,8 +1,17 @@
 # Create your views here.
 from django.http import HttpResponse
+import http.client, urllib.parse
 from .BuildManager import *
 
 
 def index(request):
     find_project(4)
+    params = urllib.parse.urlencode({'@number': 12524, '@type': 'issue', '@action': 'show'})
+    headers = {"Content-type": "application/x-www-form-urlencoded", "Accept": "text/plain"}
+    conn = http.client.HTTPConnection("bugs.python.org")
+    conn.request("POST", "", params, headers)
+    response = conn.getresponse()
+    print(response.status, response.reason)
+    data = response.read()
+    conn.close()
     return HttpResponse("Hello, world. You're at the build manager index.")

--- a/raspberryq/queuemanager/queue.py
+++ b/raspberryq/queuemanager/queue.py
@@ -218,6 +218,18 @@ class QueueManager(object):
                 return True
         return False
 
+    def addToFailureQueue(self, topic, task_id):
+        if topic not in self.queues:
+            return False
+        for task in self.queues[topic].heap:
+            if task.task_id == task_id:
+                temp = task
+                temp.status = TaskState.FAILURE
+                self.failure_queue.enqueue(temp)
+                self.queues[topic].heap.remove(task)
+                return True
+        return False
+
     def checkStatus(self, topic, task_id):
         """
         Method to check task status.
@@ -238,10 +250,12 @@ class QueueManager(object):
 
         for task in self.success_queue.heap:
             if task.task_id == task_id:
+                self.success_queue.heap.remove(task)
                 return task.status  # Return success status
 
         for task in self.failure_queue.heap:
             if task.task_id == task_id:
+                self.failure_queue.heap.remove(task)
                 return task.status  # Return failure status
 
         return "NOT_FOUND"

--- a/raspberryq/queuemanager/urls.py
+++ b/raspberryq/queuemanager/urls.py
@@ -5,9 +5,15 @@ from . import views
 
 urlpatterns = [
     url(r'^$', views.createQueue, name='createqueue'),
+    # enqueue
     url(r'^enqueue$', views.enqueue, name='enqueue'),
+    # dequeue
     url(r'^dequeue/(?P<topic>\w{0,50})$', views.dequeue, name='views.dequeue'),
+    # successq
     url(r'^successq$', views.addToSuccessQueue, name='views.addToSuccessQueue'),
+    # failureq
+    url(r'^failureq$', views.addToFailureQueue, name='views.addToFailureQueue'),
+    # checkStatus
     url(r'^checkStatus$', views.checkStatus, name='views.checkStatus'),
 
 ]

--- a/raspberryq/queuemanager/views.py
+++ b/raspberryq/queuemanager/views.py
@@ -83,7 +83,9 @@ def dequeue(request, topic):
 @require_http_methods(["POST"])
 def addToSuccessQueue(request):
     """
+     http://127.0.0.1:8000/queue/successq
     {"topic":"<topic>", "task_id":<task_id>}
+
     :param request:
     :return:
     """
@@ -91,6 +93,25 @@ def addToSuccessQueue(request):
     body_data = json.loads(body_unicode)
 
     success = manager.addToSuccessQueue(body_data['topic'], body_data['task_id'])
+    if not success:
+        error = {"error": "Either queue is not present or is Empty", "topic": body_data['topic']}
+        return HttpResponse(json.dumps(error))
+    return HttpResponse("")
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def addToFailureQueue(request):
+    """
+     http://127.0.0.1:8000/queue/failureq
+    {"topic":"<topic>", "task_id":<task_id>}
+    :param request:
+    :return:
+    """
+    body_unicode = request.body.decode('utf-8')
+    body_data = json.loads(body_unicode)
+    print(body_data)
+    success = manager.addToFailureQueue(body_data['topic'], body_data['task_id'])
     if not success:
         error = {"error": "Either queue is not present or is Empty", "topic": body_data['topic']}
         return HttpResponse(json.dumps(error))


### PR DESCRIPTION
Implemented build worker with queue support. 
You can fire /build/<project_id> request which will be queued up. Worker will fetch it and work on it and update status as success or failure. You can check status at /checkStatus url. 
